### PR TITLE
 ux:lien back-office dans le navbar (#71)

### DIFF
--- a/frontend/src/css/components/_blog.scss
+++ b/frontend/src/css/components/_blog.scss
@@ -77,6 +77,15 @@
         gap: f.rem(6);
       }
 
+      &__link--admin {
+        font-size: f.rem(13);
+        opacity: 0.6;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
+
       &__cta {
         display: inline-flex;
         align-items: center;

--- a/frontend/src/js/components/navbar.js
+++ b/frontend/src/js/components/navbar.js
@@ -1,4 +1,5 @@
 // navbar — à importer dans chaque page, nécessite <div id="navbar-placeholder"></div>
+import { API_BASE } from '../services/api.js';
 
 const NAVBAR_HTML = `
 <header class="site-header" id="site-header">
@@ -6,14 +7,9 @@ const NAVBAR_HTML = `
     <a href="/" class="logo-link">DevFlow</a>
 
     <nav class="main-nav" id="main-nav" aria-label="Navigation principale">
-      <ul class="main-nav__list">
-        <li><a href="/" class="main-nav__link">Accueil</a></li>
-        <li><a href="#" class="main-nav__link">À propos</a></li>
-        <li><a href="#" class="main-nav__link">Contact</a></li>
-      </ul>
+      <ul class="main-nav__list"></ul>
       <div class="main-nav__auth">
-        <a href="#" class="main-nav__link">S'inscrire</a>
-        <a href="#" class="main-nav__cta">Se connecter</a>
+        <a href="${API_BASE}/admin" class="main-nav__link main-nav__link--admin" target="_blank" rel="noopener noreferrer">Administration</a>
       </div>
     </nav>
 


### PR DESCRIPTION
- Remplacement des liens S'inscrire / Se connecter par un lien Administration pointant vers le back-office.
- Suppression des liens morts À propos et Contact.
- URL construite depuis API_BASE pour s'adapter automatiquement au déploiement. Closes #71